### PR TITLE
fix(seo): resolve FAQPage schema duplication issue

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import { Merriweather } from 'next/font/google';
 import Image from 'next/image';
 import Link from 'next/link';
 import './globals.css';
-import { WebSiteJsonLd, FAQJsonLd, OrganizationJsonLd } from './components/JsonLd';
+import { WebSiteJsonLd, OrganizationJsonLd } from './components/JsonLd';
 import SkipNavigation from './components/SkipNavigation';
 import ServiceWorkerRegistration from './components/ServiceWorkerRegistration';
 import { Analytics } from '@vercel/analytics/react';
@@ -106,7 +106,6 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
             <head>
                 <WebSiteJsonLd />
                 <OrganizationJsonLd />
-                <FAQJsonLd />
             </head>
             <body className={merriweather.className}>
                 <SkipNavigation />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import YearSelector from './components/YearSelector';
 import LawsSection from './components/LawsSection/LawsSection';
 import CalendarExport from './components/CalendarExport';
 import { getHolidaysByYear, getVacationOptimizationByYear } from './utils/dataUtils';
+import { FAQJsonLd } from './components/JsonLd';
 
 export const metadata: Metadata = {
   title: 'Feriados en Chile 2025 - Calendario de Días Festivos',
@@ -56,6 +57,7 @@ export default async function HomePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
+      <FAQJsonLd />
       
       <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
         <div className="container mx-auto px-4 py-8">


### PR DESCRIPTION
## Summary
- Removed global FAQJsonLd from root layout to prevent duplication
- Added FAQJsonLd only to specific pages that need FAQ content
- Fixed Google Search Console validation error for duplicate FAQPage schema

## Problem
Google Search Console detected duplicate FAQPage schema markup on the website, particularly on the `/feriados-irrenunciables` page. This was caused by FAQJsonLd being included in both the root layout (applying globally) and specific pages.

## Solution
- **Removed FAQJsonLd from `/app/layout.tsx`** - It was being applied globally to all pages
- **Added FAQJsonLd to home page (`/app/page.tsx`)** - With general FAQ content
- **Kept FAQJsonLd on `/feriados-irrenunciables` page** - With page-specific FAQ content

## Test Plan
✅ Build succeeded without errors
✅ Each page now has only one FAQPage schema
✅ No duplicate schema warnings expected in Google Search Console

## Impact
- Improved SEO by fixing structured data validation errors
- Better search engine understanding of FAQ content
- Each page now has appropriate and unique FAQ schemas

🤖 Generated with [Claude Code](https://claude.ai/code)